### PR TITLE
Fixed Saturday Translation in German

### DIFF
--- a/IcgSoftware.RecurrenceRuleToText/Language.de.resx
+++ b/IcgSoftware.RecurrenceRuleToText/Language.de.resx
@@ -186,7 +186,7 @@
     <value>Freitag</value>
   </data>
   <data name="Saturday" xml:space="preserve">
-    <value>Sonnabend</value>
+    <value>Samstag</value>
   </data>
   <data name="Sunday" xml:space="preserve">
     <value>Sonntag</value>


### PR DESCRIPTION
Samstag is more common. "Sonnabend" is only used in some north and east parts of Germany.